### PR TITLE
Simplify code for ensemble of simulated paths

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -94,23 +94,16 @@ Ensemble combining ETS and ARIMA sample paths
 
 ```{r ensemble, message=FALSE}
 ensemble <- fit %>%
-  select(ETS, ARIMA) %>%
+  select(-SNAIVE) %>%
   generate(times = 10000, h = "1 year") %>%
-  as_tibble() %>%
-  select(-.rep, -.model) %>%
-  nest(sample = -date) %>%
-  group_by(date) %>%
   summarise(
-    .model = "ENSEMBLE",
-    sample = list(unname(unlist(sample)))
+    value = dist_sample(list(.sim)),
+    .mean = mean(value)
   ) %>%
-  ungroup() %>%
   mutate(
-    value = dist_sample(sample),
-    .mean = mean(value),
-  ) %>%
-  select(-sample) %>%
-  as_fable(index = date, key = ".model", distribution = value, response = "value")
+    .model = "ENSEMBLE"
+  ) %>% 
+  as_fable(distribution = value, response = "value")
 ```
 
 CRPS calculations

--- a/README.md
+++ b/README.md
@@ -83,23 +83,16 @@ Ensemble combining ETS and ARIMA sample paths
 
 ``` r
 ensemble <- fit %>%
-  select(ETS, ARIMA) %>%
+  select(-SNAIVE) %>%
   generate(times = 10000, h = "1 year") %>%
-  as_tibble() %>%
-  select(-.rep, -.model) %>%
-  nest(sample = -date) %>%
-  group_by(date) %>%
   summarise(
-    .model = "ENSEMBLE",
-    sample = list(unname(unlist(sample)))
+    value = dist_sample(list(.sim)),
+    .mean = mean(value)
   ) %>%
-  ungroup() %>%
   mutate(
-    value = dist_sample(sample),
-    .mean = mean(value),
-  ) %>%
-  select(-sample) %>%
-  as_fable(index = date, key = ".model", distribution = value, response = "value")
+    .model = "ENSEMBLE"
+  ) %>% 
+  as_fable(distribution = value, response = "value")
 #> Warning: The dimnames of the fable's distribution are missing and have been set
 #> to match the response variables.
 ```
@@ -124,6 +117,6 @@ crps %>%
 #> 1 SNAIVE      Test   68.6        0  
 #> 2 ARIMA       Test   32.9       52.0
 #> 3 ETS         Test   31.5       54.0
-#> 4 ENSEMBLE    Test   31.4       54.3
-#> 5 COMBINATION Test   30.9       54.9
+#> 4 COMBINATION Test   30.9       54.9
+#> 5 ENSEMBLE    Test   29.7       56.7
 ```

--- a/quantile_ensembles.Rmd
+++ b/quantile_ensembles.Rmd
@@ -156,21 +156,14 @@ For the Australian café data, we can combine 10000 simulated sample paths from 
 ensemble <- fit %>%
   select(-SNAIVE) %>%
   generate(times = 10000, h = "1 year") %>%
-  as_tibble() %>%
-  select(-.rep, -.model) %>%
-  nest(sample = -date) %>%
-  group_by(date) %>%
   summarise(
-    .model = "ENSEMBLE",
-    sample = list(unname(unlist(sample)))
+    value = dist_sample(list(.sim)),
+    .mean = mean(value)
   ) %>%
-  ungroup() %>%
   mutate(
-    value = dist_sample(sample),
-    .mean = mean(value),
-  ) %>%
-  select(-sample) %>%
-  as_fable(index = date, key = ".model", distribution = value, response = "value")
+    .model = "ENSEMBLE"
+  ) %>% 
+  as_fable(distribution = value, response = "value")
 ensemble %>%
   accuracy(cafe, measures = list(CRPS = CRPS)) %>%
   mutate(


### PR DESCRIPTION
There is no need to drop the tsibble class when combining sample paths to produce an ensembled fable. Reducing the row structure over `.model` can be done directly with `summarise()`.

I would also have placed `.model = "ENSEMBLE"` in the `summarise()` call, but there is a bug with tsibble: https://github.com/tidyverts/tsibble/issues/214. Generally speaking, the `.model` column should not be necessary in a fable (https://github.com/tidyverts/fabletools/issues/96), but many functions in fabletools still assume it exists (like `accuracy()`) and need updating. The `.mean` column is also entirely optional, as all required statistics are computed directly from the distribution now.